### PR TITLE
Have the same regex for kibana-int urls in router and es_proxy

### DIFF
--- a/lib/es_proxy.rb
+++ b/lib/es_proxy.rb
@@ -86,7 +86,7 @@ class ESProxy < Forwarder
 		when %r{\A/logstash-[\d\.]{10}/_search/*?\z}
 			# 
 			rewrite_search_request
-		when %r{\A/kibana-int/dashboard/\w+\z}
+		when %r{\A/kibana-int/dashboard/\w+}
 			privatise_dashboard
 		else
 			raise 'You should not be here, this is a bug'


### PR DESCRIPTION
I have dashboards with multiple words and some symbols. This pull syncs the regexes from router and es_proxy.
