### PR TITLE
Rewrite requests that access multiple indices

### DIFF
--- a/lib/es_proxy.rb
+++ b/lib/es_proxy.rb
@@ -80,7 +80,7 @@ class ESProxy < Forwarder
 			# Flag the aliases to be requested when we make the
 			# request later on
 			@env['ALIAS_REQUEST'] = true
-		when %r{\A/logstash-[\d\.]{10}/_search/*?\z}
+		when %r{\A/logstash-[\d\.]{10}(,logstash-[\d\.]{10})*/_search/*?\z}
 			rewrite_search_request
 		when %r{\A/kibana-int/dashboard/}
 			privatise_dashboard
@@ -93,7 +93,7 @@ class ESProxy < Forwarder
 		end
 	end
 
-	# Try to make a search safe, by inserting _customer_id before the
+	# Try to make a search safe, by inserting _user_id before the
 	# /_search in a string ending in /_search
 	#
 	# This means that the request will be for the filtered alias as opposed
@@ -102,9 +102,9 @@ class ESProxy < Forwarder
 		match = @env['PATH_INFO'] =~ /\/_search\z/
 		raise "Couldn't make search safe, exploding" unless match
 
-		@env['PATH_INFO'].insert(
-			match,
-			"_#{self.user_id}"
+		@env['PATH_INFO'].gsub!(
+			/(logstash-[\d\.]{10})/,
+			"\\1_#{self.user_id}"
 		)
 	end
 

--- a/lib/router.rb
+++ b/lib/router.rb
@@ -13,7 +13,7 @@ class Router
 		[%r{\A/[^/]*/_mapping/*?\z}      , :upstream_elastic_search] ,
 		[%r{\A/_nodes/?\z}               , :upstream_elastic_search] ,
 		[
-			%r{\A/logstash-[\d\.]{10}/_search/*?\z},
+			%r{\A/logstash-[\d\.]{10}(,logstash-[\d\.]{10})*/_search/*?\z},
 			:upstream_elastic_search
 		],
 		[%r{\A/kibana-int/dashboard/}    , :upstream_elastic_search] ,

--- a/spec/lib/es_proxy_spec.rb
+++ b/spec/lib/es_proxy_spec.rb
@@ -66,6 +66,25 @@ describe ::ESProxy do
 			expect(last_response.body).to eql('PONY LOGS')
 		end
 
+		it 'makes safe a search on a protected indices' do
+			# Should proxy a request to the alias created before
+			stub_request(
+				:get,
+				"http://localhost:9200/"\
+					"logstash-2013.08.02_"\
+					"baee1068429a8e0b44179ca85b8d51bf3a"\
+					"10746d"\
+					",logstash-2013.08.03_"\
+					"baee1068429a8e0b44179ca85b8d51bf3a"\
+					"10746d"\
+					"/_search"
+			).to_return(:status => 200, :body => "PONY MULTI LOGS")
+
+			get('/logstash-2013.08.02,logstash-2013.08.03/_search')
+			expect(last_response.status).to eql(200)
+			expect(last_response.body).to eql('PONY MULTI LOGS')
+		end
+
 		it 'makes private a put to dashboards' do
 			stub_request(
 				:put,


### PR DESCRIPTION
Hi,

Kibana (latest HEAD, I don't know if it did that in previous versions) did a query on the following URL:

  /logstash-2013.11.13,logstash-2013.11.12/_search

kibana3_auth didn't properly secure it:

  /logstash-2013.11.13,logstash-2013.11.12_ab1beaceb12e73819376633cfa3d2e7a16b29bf1

This commit fixes this:

  /logstash-2013.11.13_ab1beaceb12e73819376633cfa3d2e7a16b29bf1,logstash-2013.11.12_ab1beaceb12e73819376633cfa3d2e7a16b29bf1/_search

I've included a test as well.
