### PR TITLE
adding gem Thin for Safari 7.0.3 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'http://rubygems.org'
 
 gem 'rack'
 gem 'json'
+gem 'thin'
 
 group :development do
 	gem 'shotgun'


### PR DESCRIPTION
To use Kibana3_auth in Safari 7.0.3 i've used the gem Thin for compatibilty. do you see any issues for adding this tot the Kibana3_auth module?
